### PR TITLE
Start KDE bandwidth search from Silverman's rule

### DIFF
--- a/src/util/kde.jl
+++ b/src/util/kde.jl
@@ -16,8 +16,8 @@ function TD(b::Real, x::Vector{<:Real})
 
     val = zero(eltype(x))
 
-    @inbounds @simd for i in 1:(n-1)
-        for j in (i+1):n
+    @inbounds @simd for i in 1:(n - 1)
+        for j in (i + 1):n
             val += @views 2 * ϕ6(b^(-1) * (x[i] - x[j]))
         end
     end
@@ -33,12 +33,12 @@ function TD(b::Real, data::BinnedData)
 
     val = zero(eltype(data.grid))
 
-    @inbounds @simd for i in 1:(nbins-1)
-        for j in (i+1):nbins
+    @inbounds @simd for i in 1:(nbins - 1)
+        for j in (i + 1):nbins
             val += @views 2 *
-                          data.weights[i] *
-                          data.weights[j] *
-                          ϕ6(b^(-1) * (data.grid[i] - data.grid[j]))
+                data.weights[i] *
+                data.weights[j] *
+                ϕ6(b^(-1) * (data.grid[i] - data.grid[j]))
         end
     end
 
@@ -52,8 +52,8 @@ function SD(α::Real, x::AbstractVector{<:Real})
 
     val = zero(eltype(x))
 
-    @inbounds @simd for i in 1:(n-1)
-        for j in (i+1):n
+    @inbounds @simd for i in 1:(n - 1)
+        for j in (i + 1):n
             val += @views 2 * ϕ4(α^(-1) * (x[i] - x[j]))
         end
     end
@@ -68,12 +68,12 @@ function SD(α::Real, data::BinnedData)
 
     val = zero(eltype(data.grid))
 
-    @inbounds @simd for i in 1:(nbins-1)
-        for j in (i+1):nbins
+    @inbounds @simd for i in 1:(nbins - 1)
+        for j in (i + 1):nbins
             val += @views 2 *
-                          data.weights[i] *
-                          data.weights[j] *
-                          ϕ4(α^(-1) * (data.grid[i] - data.grid[j]))
+                data.weights[i] *
+                data.weights[j] *
+                ϕ4(α^(-1) * (data.grid[i] - data.grid[j]))
         end
     end
 
@@ -85,7 +85,7 @@ end
 #=
 S. J. Sheather, M. C. Jones, A Reliable Data-Based Bandwidth Selection Method for Kernel Density Estimation, Journal of the Royal Statistical Society: Series B (Methodological), Volume 53, Issue 3, July 1991, Pages 683–690, https://doi.org/10.1111/j.2517-6161.1991.tb01857.x
 =#
-function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer=0)
+function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer = 0)
     λ = iqr(x)
     n = length(x)
 
@@ -100,7 +100,7 @@ function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer=0)
 
     α₂ = 1.357 * (SD(a, data) / TD(b, data))^(1 / 7)
 
-    # solve in log-space to avoid unconstrained Newton step on h jumping to h < 0. 
+    # solve in log-space to avoid unconstrained Newton step on h jumping to h < 0.
     function f(u)
         h = exp(u)
         α₂_h = α₂ * h^(5 / 7)
@@ -108,7 +108,7 @@ function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer=0)
         return log(C) - u
     end
 
-    h0 = 0.9 * min(std(x), iqr(x) / 1.34) * length(x)^(-1/5)   # scale-aware initial guess Silverman's rule of thumb
+    h0 = 0.9 * min(std(x), iqr(x) / 1.34) * length(x)^(-1 / 5)   # scale-aware initial guess Silverman's rule of thumb
 
     return exp(newtonraphson(log(h0), f, 1.0e-3, 1.0e-10, 10^3)), data
 end
@@ -119,5 +119,5 @@ end
 
 function kde(h::Real, x::Real, X::BinnedData)
     return sum(X.weights)^(-1) *
-           sum([h^(-1) * wⱼ * ϕ(h^(-1) * (x - xⱼ)) for (xⱼ, wⱼ) in zip(X.grid, X.weights)])
+        sum([h^(-1) * wⱼ * ϕ(h^(-1) * (x - xⱼ)) for (xⱼ, wⱼ) in zip(X.grid, X.weights)])
 end

--- a/src/util/kde.jl
+++ b/src/util/kde.jl
@@ -108,7 +108,7 @@ function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer = 0)
         return log(C) - u
     end
 
-    h0 = 0.9 * min(std(x), iqr(x) / 1.34) * length(x)^(-1 / 5)   # scale-aware initial guess Silverman's rule of thumb
+    h0 = 0.9 * min(std(x), λ / 1.34) * n^(-1 / 5)   # scale-aware initial guess Silverman's rule of thumb
 
     return exp(newtonraphson(log(h0), f, 1.0e-3, 1.0e-10, 10^3)), data
 end

--- a/src/util/kde.jl
+++ b/src/util/kde.jl
@@ -16,8 +16,8 @@ function TD(b::Real, x::Vector{<:Real})
 
     val = zero(eltype(x))
 
-    @inbounds @simd for i in 1:(n - 1)
-        for j in (i + 1):n
+    @inbounds @simd for i in 1:(n-1)
+        for j in (i+1):n
             val += @views 2 * ϕ6(b^(-1) * (x[i] - x[j]))
         end
     end
@@ -33,12 +33,12 @@ function TD(b::Real, data::BinnedData)
 
     val = zero(eltype(data.grid))
 
-    @inbounds @simd for i in 1:(nbins - 1)
-        for j in (i + 1):nbins
+    @inbounds @simd for i in 1:(nbins-1)
+        for j in (i+1):nbins
             val += @views 2 *
-                data.weights[i] *
-                data.weights[j] *
-                ϕ6(b^(-1) * (data.grid[i] - data.grid[j]))
+                          data.weights[i] *
+                          data.weights[j] *
+                          ϕ6(b^(-1) * (data.grid[i] - data.grid[j]))
         end
     end
 
@@ -52,8 +52,8 @@ function SD(α::Real, x::AbstractVector{<:Real})
 
     val = zero(eltype(x))
 
-    @inbounds @simd for i in 1:(n - 1)
-        for j in (i + 1):n
+    @inbounds @simd for i in 1:(n-1)
+        for j in (i+1):n
             val += @views 2 * ϕ4(α^(-1) * (x[i] - x[j]))
         end
     end
@@ -68,12 +68,12 @@ function SD(α::Real, data::BinnedData)
 
     val = zero(eltype(data.grid))
 
-    @inbounds @simd for i in 1:(nbins - 1)
-        for j in (i + 1):nbins
+    @inbounds @simd for i in 1:(nbins-1)
+        for j in (i+1):nbins
             val += @views 2 *
-                data.weights[i] *
-                data.weights[j] *
-                ϕ4(α^(-1) * (data.grid[i] - data.grid[j]))
+                          data.weights[i] *
+                          data.weights[j] *
+                          ϕ4(α^(-1) * (data.grid[i] - data.grid[j]))
         end
     end
 
@@ -85,7 +85,7 @@ end
 #=
 S. J. Sheather, M. C. Jones, A Reliable Data-Based Bandwidth Selection Method for Kernel Density Estimation, Journal of the Royal Statistical Society: Series B (Methodological), Volume 53, Issue 3, July 1991, Pages 683–690, https://doi.org/10.1111/j.2517-6161.1991.tb01857.x
 =#
-function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer = 0)
+function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer=0)
     λ = iqr(x)
     n = length(x)
 
@@ -100,13 +100,17 @@ function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer = 0)
 
     α₂ = 1.357 * (SD(a, data) / TD(b, data))^(1 / 7)
 
-    function f(h)
+    # solve in log-space to avoid unconstrained Newton step on h jumping to h < 0. 
+    function f(u)
+        h = exp(u)
         α₂_h = α₂ * h^(5 / 7)
-
-        return ((1 / (2 * sqrt(π))) / (3 * SD(α₂_h, data)))^(1 / 5) * n^(-1 / 5) - h
+        C = ((1 / (2 * sqrt(π))) / (3 * SD(α₂_h, data)))^(1 / 5) * n^(-1 / 5)
+        return log(C) - u
     end
+
     h0 = 0.9 * min(std(x), iqr(x) / 1.34) * length(x)^(-1/5)   # scale-aware initial guess Silverman's rule of thumb
-    return newtonraphson(h0, f, 1.0e-3, 1.0e-10, 10^3), data
+
+    return exp(newtonraphson(log(h0), f, 1.0e-3, 1.0e-10, 10^3)), data
 end
 
 function kde(h::Real, x::Real, X::AbstractVector{<:Real})
@@ -115,5 +119,5 @@ end
 
 function kde(h::Real, x::Real, X::BinnedData)
     return sum(X.weights)^(-1) *
-        sum([h^(-1) * wⱼ * ϕ(h^(-1) * (x - xⱼ)) for (xⱼ, wⱼ) in zip(X.grid, X.weights)])
+           sum([h^(-1) * wⱼ * ϕ(h^(-1) * (x - xⱼ)) for (xⱼ, wⱼ) in zip(X.grid, X.weights)])
 end

--- a/src/util/kde.jl
+++ b/src/util/kde.jl
@@ -105,8 +105,8 @@ function sheather_jones_bandwidth(x::AbstractVector, nbins::Integer = 0)
 
         return ((1 / (2 * sqrt(π))) / (3 * SD(α₂_h, data)))^(1 / 5) * n^(-1 / 5) - h
     end
-
-    return newtonraphson(1.0, f, 1.0e-3, 1.0e-10, 10^3), data
+    h0 = 0.9 * min(std(x), iqr(x) / 1.34) * length(x)^(-1/5)   # scale-aware initial guess Silverman's rule of thumb
+    return newtonraphson(h0, f, 1.0e-3, 1.0e-10, 10^3), data
 end
 
 function kde(h::Real, x::Real, X::AbstractVector{<:Real})

--- a/test/inputs/empiricaldistribution.jl
+++ b/test/inputs/empiricaldistribution.jl
@@ -137,7 +137,7 @@ end
 @testitem "EmpiricalDiistribution: Linear binning" setup = [TestSetup] begin
     x = [randn(10_000)..., (5 .+ randn(10_000))...]
 
-    ed = EmpiricalDistribution(x; nbins=2^12)
+    ed = EmpiricalDistribution(x; nbins = 2^12)
 
     @test mean(ed) ≈ 2.5 atol = 0.1
 

--- a/test/inputs/empiricaldistribution.jl
+++ b/test/inputs/empiricaldistribution.jl
@@ -66,12 +66,40 @@
     @test logpdf.(ed, samples) ≈ log.(pdf.(ed, samples))
 
     @test quantile.(ed, cdf.(ed, samples)) ≈ samples
+
+    z = randn(1000)
+
+    ed = EmpiricalDistribution(2000 .* z)
+
+    @test ed.h ≈ 405.5731952771436
+
+    @test mean(ed) ≈ -133.08049905065332
+    @test var(ed) ≈ 4.0436509067724207e6
+
+    @test all(insupport.(ed, z))
+    @test all(pdf.(ed, z) .>= 0)
+
+    samples = rand(ed, 10000)
+
+    @test all(insupport.(ed, samples))
+    @test all(pdf.(ed, samples) .>= 0)
+
+    @test pdf(ed, minimum(ed)) ≈ 0.0 atol = 1.0e-10
+    @test pdf(ed, maximum(ed)) ≈ 0.0 atol = 1.0e-10
+
+    pdf_area, _ = hquadrature(x -> pdf(ed, x), minimum(ed), maximum(ed))
+
+    @test pdf_area ≈ 1 atol = 0.01
+    @test logpdf.(ed, samples) ≈ log.(pdf.(ed, samples))
+
+    @test quantile.(ed, cdf.(ed, samples)) ≈ samples
+
 end
 
 @testitem "EmpiricalDiistribution: Linear binning" setup = [TestSetup] begin
     x = [randn(10_000)..., (5 .+ randn(10_000))...]
 
-    ed = EmpiricalDistribution(x; nbins = 2^12)
+    ed = EmpiricalDistribution(x; nbins=2^12)
 
     @test mean(ed) ≈ 2.5 atol = 0.1
 

--- a/test/inputs/empiricaldistribution.jl
+++ b/test/inputs/empiricaldistribution.jl
@@ -67,20 +67,61 @@
 
     @test quantile.(ed, cdf.(ed, samples)) ≈ samples
 
-    z = randn(1000)
+    # high magnitude data
 
-    ed = EmpiricalDistribution(2000 .* z)
+    data = [
+        -0.3634,
+        0.2517,
+        -0.315,
+        -0.3113,
+        0.8163,
+        0.4767,
+        -0.8596,
+        -1.4693,
+        -2.1143,
+        0.0438,
+        -0.8253,
+        0.8403,
+        0.4339,
+        -0.3954,
+        0.5171,
+        1.4472,
+        -0.0931,
+        -1.2726,
+        -0.3107,
+        -0.0966,
+        -1.3828,
+        -1.4624,
+        1.301,
+        2.2663,
+        1.5124,
+        0.6488,
+        0.8999,
+        0.2842,
+        1.1036,
+        0.6639,
+        0.1713,
+        1.1199,
+        1.9208,
+        0.8006,
+        -0.3856,
+        -0.4397,
+        0.6299,
+        -0.0696,
+        -0.7789,
+        -0.8787,
+    ]
 
-    @test ed.h ≈ 405.5731952771436
+    ed = EmpiricalDistribution(2000 .* data)      # large-scale: pre-fix this threw DomainError
 
-    @test mean(ed) ≈ -133.08049905065332
-    @test var(ed) ≈ 4.0436509067724207e6
+    @test ed.h ≈ 851.4141601336096
+    @test mean(ed) ≈ 216.2649999999922
+    @test var(ed) ≈ 4.513752626845226e6
 
-    @test all(insupport.(ed, z))
-    @test all(pdf.(ed, z) .>= 0)
+    @test all(insupport.(ed, 2000 .* data))
+    @test all(pdf.(ed, 2000 .* data) .>= 0)
 
     samples = rand(ed, 10000)
-
     @test all(insupport.(ed, samples))
     @test all(pdf.(ed, samples) .>= 0)
 
@@ -88,12 +129,9 @@
     @test pdf(ed, maximum(ed)) ≈ 0.0 atol = 1.0e-10
 
     pdf_area, _ = hquadrature(x -> pdf(ed, x), minimum(ed), maximum(ed))
-
     @test pdf_area ≈ 1 atol = 0.01
     @test logpdf.(ed, samples) ≈ log.(pdf.(ed, samples))
-
     @test quantile.(ed, cdf.(ed, samples)) ≈ samples
-
 end
 
 @testitem "EmpiricalDiistribution: Linear binning" setup = [TestSetup] begin


### PR DESCRIPTION
`EmpiricalDistrution`was failing for high magnitude dataset (big numbers with big spread), as explained in #340. Introducing the Silverman's rule of thumb lead to a failure of the previous test leading to a negative bandwidth. Turned out that the problem was in the newton step to evaluate `h` cause it was not constrained to only positive, for this reason the function have been modified to be solved in the log-space and then exp-back.

Closes #340